### PR TITLE
Ported infer.py

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 module.exports = {
+	infer: require('./infer'),
 	types: require('./types')
 }

--- a/infer.js
+++ b/infer.js
@@ -1,0 +1,80 @@
+var types = require('./types');
+
+
+module.exports = function(headers, values, options) {
+  /*
+  Return a schema from the passed headers and values.
+
+  Args:
+  * `headers`: a list of header names
+  * `values`: a reader over data, yielding each row as a list of values
+  * `explicit`: be explicit.
+  * `primaryKey`: pass in a primary key or iterable of keys.
+  Returns:
+  * A JSON Table Schema as a Python dict.
+  */
+
+  // Set up default options
+  options = _.extend({
+    rowLimit: null,
+    explicit: false,
+    primaryKey: null
+  }, options);
+
+  guesser = types.TypeGuesser();
+  resolver = types.TypeResolver();
+  schema = {fields: []};
+  typeMatches = {};
+
+  if(options.primaryKey)
+    schema['primaryKey'] = options.primaryKey;
+
+   schema['fields'] = headers.map(function(H) {
+    var constraints = {};
+    var descriptor;
+
+
+    descriptor = {
+      name: header,
+      title: '',
+      description: '',
+    };
+
+    if(options.explicit)
+      constraints.required = true;
+
+    if(H === options.primaryKey)
+      constraints.unique = true;
+
+    if(_.isEmpty(constraints))
+      descriptor.constraints = constraints;
+   });
+
+  for(var index in values) {
+    var rowLength;
+
+
+    if(options.rowLimit && (index > options.rowLimit))
+      break;
+
+    // Normalize rows with invalid dimensions for sanity
+    rowLength = value[index].length;
+    headersLength = headers.length;
+
+    if(rowLength > headersLength)
+      row = _.first(row, headersLength);
+
+    if(rowLength < headersLength)
+      row = row.concat(_.range(headersLength - rowLength).map(function() { return ''; }));
+
+    // Build a column-wise lookup of type matches
+    for(var index in row)
+      typeMatches[index] = (typeMatches[index] || []).concat(guesser.cast(row[index]));
+  }
+
+  // Choose a type/format for each column based on the matches
+  for(var typeMatch in _.pairs(typeMatches))
+    _.extend(schema['fields'][typeMatch[0]], resolver.get(typeMatch[1]));
+
+  return schema;
+}

--- a/infer.js
+++ b/infer.js
@@ -47,7 +47,7 @@ module.exports = function(headers, values, options) {
     if(H === options.primaryKey)
       constraints.unique = true;
 
-    if(_.isEmpty(constraints))
+    if(!_.isEmpty(constraints))
       descriptor.constraints = constraints;
 
     return descriptor;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "csv": "^0.4.2",
     "promise-polyfill": "^2.0.2",
     "superagent": "^1.2.0",
     "underscore": "^1.8.3"
@@ -15,7 +16,6 @@
     "moment": "^2.10.3",
     "superagent-mock": "^1.1.0"
   },
-
   "scripts": {
     "test": "mocha"
   },

--- a/test/CSV.js
+++ b/test/CSV.js
@@ -1,0 +1,4 @@
+module.exports = {
+  dataInfer: 'id,age,name\n1,39,Paul\n2,23,Jimmy\n3,36,Jane\n4,28,Judy',
+  dataInferRowLimit: 'id,age,name\n1,39,Paul\n2,23,Jimmy\n3,36,Jane\n4,28,Judy\nqwerty,nineteen,Rose\nwerty,nineteen,Red\nerty,nineteen,Rotem\nrty,nineteen,Ruth\nty,nineteen,Amber\ny,nineteen,Angel\n_,nineteen,Angie'
+};

--- a/test/infer.js
+++ b/test/infer.js
@@ -37,6 +37,7 @@ describe('Infer', function() {
       var primaryKey = 'id';
       var schema = infer(D[0], _.rest(D), {primaryKey: primaryKey});
 
+
       assert.equal(schema.primaryKey, primaryKey);
       done();
     });
@@ -46,6 +47,7 @@ describe('Infer', function() {
     csv.parse(CSVData.dataInfer, function(E, D) {
       var primaryKey = ['id', 'age'];
       var schema = infer(D[0], _.rest(D), {primaryKey: primaryKey});
+
 
       assert.equal(schema.primaryKey, primaryKey);
       done();

--- a/test/infer.js
+++ b/test/infer.js
@@ -62,5 +62,13 @@ describe('Infer', function() {
     });
   });
 
-  it('create constraints if explicit param passed as True', function(done, err) { assert(); done(); });
+  it('create constraints if explicit param passed as True', function(done, err) {
+    csv.parse(CSVData.dataInfer, function(E, D) {
+      var schema = infer(D[0], _.rest(D), {explicit: true});
+
+
+      assert.ok(schema.fields[0].constraints);
+      done();
+    });
+  });
 });

--- a/test/infer.js
+++ b/test/infer.js
@@ -32,7 +32,16 @@ describe('Infer', function() {
     });
   });
 
-  it('respect primaryKey param', function(done, err) { assert(); done(); });
+  it('respect primaryKey param', function(done, err) {
+    csv.parse(CSVData.dataInferRowLimit, function(E, D) {
+      var primaryKey = 'id';
+      var schema = infer(D[0], _.rest(D), {primaryKey: primaryKey});
+
+      assert.equal(schema.primaryKey, primaryKey);
+      done();
+    });
+  });
+
   it('respect primaryKey param passed as list of fields', function(done, err) { assert(); done(); });
   it('do not create constraints if explicit param passed as False', function(done, err) { assert(); done(); });
   it('create constraints if explicit param passed as True', function(done, err) { assert(); done(); });

--- a/test/infer.js
+++ b/test/infer.js
@@ -1,12 +1,25 @@
 var _ = require('underscore');
 var assert = require('chai').assert;
-var CSV = require('./CSV');
+var csv = require('csv');
+var CSVData = require('./CSV');
 var infer = require('../').infer;
 var types = require('../').types;
 
 
+// WARN Use Model in test cases instead of validating schema directly
 describe('Infer', function() {
-  it('produce schema from a generic .csv', function(done, err) { assert(); done(); });
+  it('produce schema from a generic .csv', function(done, err) {
+    csv.parse(CSVData.dataInfer, function(E, D) {
+      var schema = infer(D[0], _.rest(D));
+
+
+      assert.equal(_.findWhere(schema.fields, {name: 'id'}).type, 'integer');
+      assert.equal(_.findWhere(schema.fields, {name: 'age'}).type, 'integer');
+      assert.equal(_.findWhere(schema.fields, {name: 'name'}).type, 'string');
+      done();
+    });
+  });
+
   it('respect rowLimit param', function(done, err) { assert(); done(); });
   it('respect primaryKey param', function(done, err) { assert(); done(); });
   it('respect primaryKey param passed as list of fields', function(done, err) { assert(); done(); });

--- a/test/infer.js
+++ b/test/infer.js
@@ -20,7 +20,18 @@ describe('Infer', function() {
     });
   });
 
-  it('respect rowLimit param', function(done, err) { assert(); done(); });
+  it('respect rowLimit param', function(done, err) {
+    csv.parse(CSVData.dataInferRowLimit, function(E, D) {
+      var schema = infer(D[0], _.rest(D), {rowLimit: 4});
+
+
+      assert.equal(_.findWhere(schema.fields, {name: 'id'}).type, 'integer');
+      assert.equal(_.findWhere(schema.fields, {name: 'age'}).type, 'integer');
+      assert.equal(_.findWhere(schema.fields, {name: 'name'}).type, 'string');
+      done();
+    });
+  });
+
   it('respect primaryKey param', function(done, err) { assert(); done(); });
   it('respect primaryKey param passed as list of fields', function(done, err) { assert(); done(); });
   it('do not create constraints if explicit param passed as False', function(done, err) { assert(); done(); });

--- a/test/infer.js
+++ b/test/infer.js
@@ -42,7 +42,16 @@ describe('Infer', function() {
     });
   });
 
-  it('respect primaryKey param passed as list of fields', function(done, err) { assert(); done(); });
+  it('respect primaryKey param passed as list of fields', function(done, err) {
+    csv.parse(CSVData.dataInfer, function(E, D) {
+      var primaryKey = ['id', 'age'];
+      var schema = infer(D[0], _.rest(D), {primaryKey: primaryKey});
+
+      assert.equal(schema.primaryKey, primaryKey);
+      done();
+    });
+  });
+
   it('do not create constraints if explicit param passed as False', function(done, err) { assert(); done(); });
   it('create constraints if explicit param passed as True', function(done, err) { assert(); done(); });
 });

--- a/test/infer.js
+++ b/test/infer.js
@@ -52,6 +52,15 @@ describe('Infer', function() {
     });
   });
 
-  it('do not create constraints if explicit param passed as False', function(done, err) { assert(); done(); });
+  it('do not create constraints if explicit param passed as False', function(done, err) {
+    csv.parse(CSVData.dataInfer, function(E, D) {
+      var schema = infer(D[0], _.rest(D), {explicit: false});
+
+
+      assert.notOk(schema.fields[0].constraints);
+      done();
+    });
+  });
+
   it('create constraints if explicit param passed as True', function(done, err) { assert(); done(); });
 });

--- a/test/infer.js
+++ b/test/infer.js
@@ -1,0 +1,15 @@
+var _ = require('underscore');
+var assert = require('chai').assert;
+var CSV = require('./CSV');
+var infer = require('../').infer;
+var types = require('../').types;
+
+
+describe('Infer', function() {
+  it('produce schema from a generic .csv', function(done, err) { assert(); done(); });
+  it('respect rowLimit param', function(done, err) { assert(); done(); });
+  it('respect primaryKey param', function(done, err) { assert(); done(); });
+  it('respect primaryKey param passed as list of fields', function(done, err) { assert(); done(); });
+  it('do not create constraints if explicit param passed as False', function(done, err) { assert(); done(); });
+  it('create constraints if explicit param passed as True', function(done, err) { assert(); done(); });
+});


### PR DESCRIPTION
Test cases depend on https://github.com/okfn/jtskit-py/blob/master/jtskit/models.py, like this one https://github.com/okfn/jtskit-py/blob/master/tests/test_infer.py#L22

Since I haven't yet ported ```models.py``` I don't use it in test cases, but perform testing directly over data returned by ```infer.js```. I can fix that when ```models.py``` is ported or leave it like this if it is acceptable.