### PR TITLE
Ported models.js

### DIFF
--- a/ensure.js
+++ b/ensure.js
@@ -149,17 +149,17 @@ module.exports = function(schema) {
 
       // Ensure that the primary key matches field names
       if(_.isString(schema.primaryKey)) {
-          if(!_.contains(fieldsNames, schema.primaryKey)) {
+        if(!_.contains(fieldsNames, schema.primaryKey)) {
+          valid = false;
+          errors = errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
+        }
+      } else {
+        _.each(schema.primaryKey, function(PK) {
+          if(_.contains(fieldsNames, PK)) {
             valid = false;
             errors = errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
           }
-      } else {
-          _.each(schema.primaryKey, function(PK) {
-            if(_.contains(fieldsNames, PK)) {
-              valid = false;
-              errors = errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
-            }
-          });
+        });
       }
   }
 

--- a/ensure.js
+++ b/ensure.js
@@ -1,6 +1,10 @@
+var _ = require('underscore');
+var utilities = require('./utilities');
+
+
 module.exports = function(schema) {
-	/*
-	Validate that `schema` is a valid JSON Table Schema.
+  /*
+  Validate that `schema` is a valid JSON Table Schema.
 
   Args:
   * `schema`: a dict to check if it is valid JSON Table Schema
@@ -9,5 +13,229 @@ module.exports = function(schema) {
   * A tuple of `valid`, `errors`
   */
 
-	return true;
+  var fieldsNames = _.map(_.result(schema, 'fields') || [], _.property('name'));
+  var errors = [];
+  var valid = true;
+
+
+  // A schema is a hash
+  if(!utilities.isHash(schema)) {
+    valid = false;
+    errors.concat('A JSON Table Schema should be a hash.')
+
+    // Return early in this case.
+    return [valid, errors];
+  }
+
+  // Which MUST contain a key `fields`
+  if(!schema.fields) {
+    valid = false;
+    errors.concat('A JSON Table Schema must have a fields key.')
+
+    // Return early in this case.
+    return [valid, errors];
+  }
+
+  // `fields` MUST be an array
+  if(!_isArray(schema.fields)) {
+    valid = false;
+    errors.concat('A JSON Table Schema must have an array of fields.');
+
+    // Return early in this case.
+    return [valid, errors];
+  }
+
+  // Each entry in the `fields` array MUST be a hash
+  if(!_.every(schema.fields, function(F) { return utilities.isHash(F); })) {
+    valid = false;
+    errors.concat('Each field in JSON Table Schema must be a hash.');
+  }
+
+  // Each entry in the `fields` array MUST have a `name` key
+  if(!_.every(schema.fields, function(F) { return Boolean(F.name); })) {
+    valid = false;
+    errors.concat('A JSON Table Schema field must have a name key.');
+  }
+
+  // Each entry in the `fields` array MAY have a `constraints` key
+  // if `constraints` is present, then `constraints` MUST be a hash
+  if(!_.every(schema.fields, function(F) { return !F.constraints || utilities.isHash(F.constraints); })) {
+    valid = false;
+    errors.concat('A JSON Table Schema field contraint must be a hash.');
+  }
+
+  // Constraints may contain certain keys (each has a specific meaning)
+  _.chain(schema['fields'])
+    .filter(function(F) { return Boolean(F.constraints); })
+
+    .each(function(F) {
+      // IF `required` key, then it is a boolean
+      if(F.constraints.required && !_.isBoolean(F.constraints.required)) {
+        valid = false;
+        errors.concat('A JSON Table Schema required constraint must be a boolean.');
+      }
+
+      // IF `minLength` key, then it is an integer
+      if(F.constraints.minLength && !_.isNumber(F.constraints.minLength)) {
+        valid = false;
+        errors.concat('A JSON Table Schema minLength constraint must be an integer.');
+      }
+
+      // IF `maxLength` key, then it is an integer
+      if(F.constraints.maxLength && !_.isNumber(F.constraints.maxLength)) {
+        valid = false;
+        errors.concat('A JSON Table Schema maxLength constraint must be an integer')
+
+      // IF `unique` key, then it is a boolean
+      if(F.constraints.unique && !_.isBoolean(F.constraints.unique)) {
+        valid = false;
+        errors.concat('A JSON Table Schema unique constraint must be a boolean.')
+      }
+
+      // IF `pattern` key, then it is a regex
+      if(F.constraints.pattern && !_.isString(F.constraints.pattern)) {
+        valid = false;
+        errors.concat('A JSON Table Schema pattern constraint must be a string.')
+      }
+
+      // IF `minimum` key, then it DEPENDS on `field` TYPE
+      if(F.constraints.minimum) {
+        // IF `type` is integer
+        if(_.isNumber(F.type) && !_.isNumber(F.constraints.minimum)) {
+          valid = false;
+          errors.concat('A JSON Table Schema minimum constraint which is an integer is only valid if the encompassing field is also of type integer');
+        }
+
+        // WARN Probably need to chack for moment() type if we decide to go with moment() for dates
+        // IF `type` is date
+        else if(_.isDate(F.type) && !_.isDate(constraints.minimum)) {
+          valid = false;
+          errors.concat('A JSON Table Schema minimum constraint which is a date is only valid if the encompassing field is also of type date');
+        }
+
+        else {
+          valid = false;
+          errors.concat('A JSON Table Schema minimum constraint is present with unclear application (field is not an integer or a date)');
+        }
+      }
+
+      if(F.constraints.maximum) {
+        // IF `type` is integer
+        if(_.isNumber(F.type) && !_.isNumber(F.constraints.maximum)) {
+          valid = false;
+          errors.concat('A JSON Table Schema maximum constraint which is an integer is only valid if the encompassing field is also of type integer');
+        }
+
+        // WARN Probably need to chack for moment() type if we decide to go with moment() for dates
+        // IF `type` is date
+        else if(_.isDate(F.type) && !_.isDate(constraints.maximum)) {
+          valid = false;
+          errors.concat('A JSON Table Schema maximum constraint which is a date is only valid if the encompassing field is also of type date');
+        }
+
+        else {
+          valid = false;
+          errors.concat('A JSON Table Schema maximum constraint is present with unclear application (field is not an integer or a date)');
+        }
+      }
+    });
+
+  // The hash MAY contain a key `primaryKey`
+  if(schema.primaryKey) {
+      // `primaryKey` MUST be a string or an array
+      if(!(_.isString(schema.primaryKey) || _.isArray(schema.primaryKey))) {
+        valid = false;
+        errors.concat('A JSON Table Schema primaryKey must be either a string or an array.');
+      }
+
+      // Ensure that the primary key matches field names
+      if(_.isString(schema.primaryKey)) {
+          if(!_.contains(fieldsNames, schema.primaryKey)) {
+            valid = false;
+            errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
+          }
+      } else {
+          _.each(schema.primaryKey, function(PK) {
+            if(_.contains(fieldsNames, PK)) {
+              valid = false;
+              errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
+            }
+          });
+      }
+  }
+
+  // The hash may contain a key `foreignKeys`
+  if(schema.get('foreignKeys')) {
+    // `foreignKeys` MUST be an array
+    if(!_.isArray(schema.foreignKeys)) {
+      valid = false;
+      errors.concat('A JSON Table Schema foreignKeys must be an array.');
+    }
+
+    // Each `foreignKey` in `foreignKeys` MUST be a hash
+    if(!_.every(schema.foreignKeys, function(FK) { return utilities.isHash(FK); })) {
+      valid = false;
+      errors.concat('A JSON Table Schema `foreignKey` must be a hash.');
+    }
+
+    // Each `foreignKey` in `foreignKeys` MUST have a `fields` key
+    if(!_.every(schema.foreignKeys, function(FK) { return Boolean(FK.fields); })) {
+      valid = false;
+      errors.concat('A JSON Table Schema foreignKey must have a fields key.');
+    }
+
+    // Each `fields` key in a `foreignKey` MUST be a string or array
+    if(!_.every(schema.foreignKeys, function(FK) { return _.isString(FK.fields) || _.isArray(FK.fields); })) {
+      valid = false;
+      errors.concat('A JSON Table Schema foreignKey.fields type must be a string or an array.');
+    }
+
+    _.each(schema.foreignKeys, function(FK) {
+      // Ensure that `foreignKey.fields` match field names
+      if(_.isString(FK.fields)) {
+        if(!_.contains(fieldsNames, FK.fields) {
+          valid = false;
+          errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
+        }
+      } else {
+        if((_.intersection(fieldsNames, FK.fields) || []).length < FK.fields.length) {
+          valid = false;
+          errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
+        };
+      }
+
+      // Ensure that `foreignKey.reference` is present and is a hash
+      if(!utilities.isHash(FK.reference)) {
+        valid = false;
+        errors.concat('A JSON Table Schema foreignKey.reference must be a hash.');
+      }
+
+      // Ensure that `foreignKey.reference` has a `resource` key
+      if(!_.contains(_.keys(FK.reference), 'resource')) {
+        valid = false;
+        errors.concat('A JSON Table Schema foreignKey.reference must have a resource key.'); 
+      }
+
+      // Ensure that `foreignKey.reference` has a `fields` key
+      if(!_.contains(_.keys(FK.reference), 'fields')) {
+        valid = false;
+        errors.concat('A JSON Table Schema foreignKey.reference must have a fields key.');
+      }
+
+      // Ensure that `foreignKey.reference.fields` matches outer `fields`
+      if(_.isString(FK.get('fields'))) {
+        if(!_.isString(FK.reference.fields)) {
+          valid = false;
+          errors.concat('A JSON Table Schema foreignKey.reference.fields must match field names.');
+        }
+      } else {
+        if(FK.fields.length !== FK.reference.fields.length) {
+          valid = false;
+          errors.concat('A JSON Table Schema must have a fields key.');
+        }
+      }
+    });
+  }
+
+  return [valid, errors];
 }

--- a/ensure.js
+++ b/ensure.js
@@ -1,0 +1,13 @@
+module.exports = function(schema) {
+	/*
+	Validate that `schema` is a valid JSON Table Schema.
+
+  Args:
+  * `schema`: a dict to check if it is valid JSON Table Schema
+
+  Returns:
+  * A tuple of `valid`, `errors`
+  */
+
+	return true;
+}

--- a/ensure.js
+++ b/ensure.js
@@ -21,7 +21,7 @@ module.exports = function(schema) {
   // A schema is a hash
   if(!utilities.isHash(schema)) {
     valid = false;
-    errors.concat('A JSON Table Schema should be a hash.')
+    errors = errors.concat('A JSON Table Schema should be a hash.')
 
     // Return early in this case.
     return [valid, errors];
@@ -30,16 +30,16 @@ module.exports = function(schema) {
   // Which MUST contain a key `fields`
   if(!schema.fields) {
     valid = false;
-    errors.concat('A JSON Table Schema must have a fields key.')
+    errors = errors.concat('A JSON Table Schema must have a fields key.')
 
     // Return early in this case.
     return [valid, errors];
   }
 
   // `fields` MUST be an array
-  if(!_isArray(schema.fields)) {
+  if(!_.isArray(schema.fields)) {
     valid = false;
-    errors.concat('A JSON Table Schema must have an array of fields.');
+    errors = errors.concat('A JSON Table Schema must have an array of fields.');
 
     // Return early in this case.
     return [valid, errors];
@@ -48,20 +48,20 @@ module.exports = function(schema) {
   // Each entry in the `fields` array MUST be a hash
   if(!_.every(schema.fields, function(F) { return utilities.isHash(F); })) {
     valid = false;
-    errors.concat('Each field in JSON Table Schema must be a hash.');
+    errors = errors.concat('Each field in JSON Table Schema must be a hash.');
   }
 
   // Each entry in the `fields` array MUST have a `name` key
   if(!_.every(schema.fields, function(F) { return Boolean(F.name); })) {
     valid = false;
-    errors.concat('A JSON Table Schema field must have a name key.');
+    errors = errors.concat('A JSON Table Schema field must have a name key.');
   }
 
   // Each entry in the `fields` array MAY have a `constraints` key
   // if `constraints` is present, then `constraints` MUST be a hash
   if(!_.every(schema.fields, function(F) { return !F.constraints || utilities.isHash(F.constraints); })) {
     valid = false;
-    errors.concat('A JSON Table Schema field contraint must be a hash.');
+    errors = errors.concat('A JSON Table Schema field contraint must be a hash.');
   }
 
   // Constraints may contain certain keys (each has a specific meaning)
@@ -72,30 +72,31 @@ module.exports = function(schema) {
       // IF `required` key, then it is a boolean
       if(F.constraints.required && !_.isBoolean(F.constraints.required)) {
         valid = false;
-        errors.concat('A JSON Table Schema required constraint must be a boolean.');
+        errors = errors.concat('A JSON Table Schema required constraint must be a boolean.');
       }
 
       // IF `minLength` key, then it is an integer
       if(F.constraints.minLength && !_.isNumber(F.constraints.minLength)) {
         valid = false;
-        errors.concat('A JSON Table Schema minLength constraint must be an integer.');
+        errors = errors.concat('A JSON Table Schema minLength constraint must be an integer.');
       }
 
       // IF `maxLength` key, then it is an integer
       if(F.constraints.maxLength && !_.isNumber(F.constraints.maxLength)) {
         valid = false;
-        errors.concat('A JSON Table Schema maxLength constraint must be an integer')
+        errors = errors.concat('A JSON Table Schema maxLength constraint must be an integer');
+      }
 
       // IF `unique` key, then it is a boolean
       if(F.constraints.unique && !_.isBoolean(F.constraints.unique)) {
         valid = false;
-        errors.concat('A JSON Table Schema unique constraint must be a boolean.')
+        errors = errors.concat('A JSON Table Schema unique constraint must be a boolean.')
       }
 
       // IF `pattern` key, then it is a regex
       if(F.constraints.pattern && !_.isString(F.constraints.pattern)) {
         valid = false;
-        errors.concat('A JSON Table Schema pattern constraint must be a string.')
+        errors = errors.concat('A JSON Table Schema pattern constraint must be a string.')
       }
 
       // IF `minimum` key, then it DEPENDS on `field` TYPE
@@ -103,19 +104,19 @@ module.exports = function(schema) {
         // IF `type` is integer
         if(_.isNumber(F.type) && !_.isNumber(F.constraints.minimum)) {
           valid = false;
-          errors.concat('A JSON Table Schema minimum constraint which is an integer is only valid if the encompassing field is also of type integer');
+          errors = errors.concat('A JSON Table Schema minimum constraint which is an integer is only valid if the encompassing field is also of type integer');
         }
 
         // WARN Probably need to chack for moment() type if we decide to go with moment() for dates
         // IF `type` is date
         else if(_.isDate(F.type) && !_.isDate(constraints.minimum)) {
           valid = false;
-          errors.concat('A JSON Table Schema minimum constraint which is a date is only valid if the encompassing field is also of type date');
+          errors = errors.concat('A JSON Table Schema minimum constraint which is a date is only valid if the encompassing field is also of type date');
         }
 
         else {
           valid = false;
-          errors.concat('A JSON Table Schema minimum constraint is present with unclear application (field is not an integer or a date)');
+          errors = errors.concat('A JSON Table Schema minimum constraint is present with unclear application (field is not an integer or a date)');
         }
       }
 
@@ -123,19 +124,17 @@ module.exports = function(schema) {
         // IF `type` is integer
         if(_.isNumber(F.type) && !_.isNumber(F.constraints.maximum)) {
           valid = false;
-          errors.concat('A JSON Table Schema maximum constraint which is an integer is only valid if the encompassing field is also of type integer');
+          errors = errors.concat('A JSON Table Schema maximum constraint which is an integer is only valid if the encompassing field is also of type integer');
         }
 
         // WARN Probably need to chack for moment() type if we decide to go with moment() for dates
         // IF `type` is date
         else if(_.isDate(F.type) && !_.isDate(constraints.maximum)) {
           valid = false;
-          errors.concat('A JSON Table Schema maximum constraint which is a date is only valid if the encompassing field is also of type date');
-        }
-
-        else {
+          errors = errors.concat('A JSON Table Schema maximum constraint which is a date is only valid if the encompassing field is also of type date');
+        } else {
           valid = false;
-          errors.concat('A JSON Table Schema maximum constraint is present with unclear application (field is not an integer or a date)');
+          errors = errors.concat('A JSON Table Schema maximum constraint is present with unclear application (field is not an integer or a date)');
         }
       }
     });
@@ -145,93 +144,93 @@ module.exports = function(schema) {
       // `primaryKey` MUST be a string or an array
       if(!(_.isString(schema.primaryKey) || _.isArray(schema.primaryKey))) {
         valid = false;
-        errors.concat('A JSON Table Schema primaryKey must be either a string or an array.');
+        errors = errors.concat('A JSON Table Schema primaryKey must be either a string or an array.');
       }
 
       // Ensure that the primary key matches field names
       if(_.isString(schema.primaryKey)) {
           if(!_.contains(fieldsNames, schema.primaryKey)) {
             valid = false;
-            errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
+            errors = errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
           }
       } else {
           _.each(schema.primaryKey, function(PK) {
             if(_.contains(fieldsNames, PK)) {
               valid = false;
-              errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
+              errors = errors.concat('A JSON Table Schema primaryKey value must be found in the schema field names');
             }
           });
       }
   }
 
   // The hash may contain a key `foreignKeys`
-  if(schema.get('foreignKeys')) {
+  if(schema.foreignKeys) {
     // `foreignKeys` MUST be an array
     if(!_.isArray(schema.foreignKeys)) {
       valid = false;
-      errors.concat('A JSON Table Schema foreignKeys must be an array.');
+      errors = errors.concat('A JSON Table Schema foreignKeys must be an array.');
     }
 
     // Each `foreignKey` in `foreignKeys` MUST be a hash
     if(!_.every(schema.foreignKeys, function(FK) { return utilities.isHash(FK); })) {
       valid = false;
-      errors.concat('A JSON Table Schema `foreignKey` must be a hash.');
+      errors = errors.concat('A JSON Table Schema `foreignKey` must be a hash.');
     }
 
     // Each `foreignKey` in `foreignKeys` MUST have a `fields` key
     if(!_.every(schema.foreignKeys, function(FK) { return Boolean(FK.fields); })) {
       valid = false;
-      errors.concat('A JSON Table Schema foreignKey must have a fields key.');
+      errors = errors.concat('A JSON Table Schema foreignKey must have a fields key.');
     }
 
     // Each `fields` key in a `foreignKey` MUST be a string or array
     if(!_.every(schema.foreignKeys, function(FK) { return _.isString(FK.fields) || _.isArray(FK.fields); })) {
       valid = false;
-      errors.concat('A JSON Table Schema foreignKey.fields type must be a string or an array.');
+      errors = errors.concat('A JSON Table Schema foreignKey.fields type must be a string or an array.');
     }
 
     _.each(schema.foreignKeys, function(FK) {
       // Ensure that `foreignKey.fields` match field names
       if(_.isString(FK.fields)) {
-        if(!_.contains(fieldsNames, FK.fields) {
+        if(!_.contains(fieldsNames, FK.fields)) {
           valid = false;
-          errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
+          errors = errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
         }
       } else {
         if((_.intersection(fieldsNames, FK.fields) || []).length < FK.fields.length) {
           valid = false;
-          errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
+          errors = errors.concat('A JSON Table Schema foreignKey.fields value must correspond with field names.');
         };
       }
 
       // Ensure that `foreignKey.reference` is present and is a hash
       if(!utilities.isHash(FK.reference)) {
         valid = false;
-        errors.concat('A JSON Table Schema foreignKey.reference must be a hash.');
+        errors = errors.concat('A JSON Table Schema foreignKey.reference must be a hash.');
       }
 
       // Ensure that `foreignKey.reference` has a `resource` key
       if(!_.contains(_.keys(FK.reference), 'resource')) {
         valid = false;
-        errors.concat('A JSON Table Schema foreignKey.reference must have a resource key.'); 
+        errors = errors.concat('A JSON Table Schema foreignKey.reference must have a resource key.'); 
       }
 
       // Ensure that `foreignKey.reference` has a `fields` key
       if(!_.contains(_.keys(FK.reference), 'fields')) {
         valid = false;
-        errors.concat('A JSON Table Schema foreignKey.reference must have a fields key.');
+        errors = errors.concat('A JSON Table Schema foreignKey.reference must have a fields key.');
       }
 
       // Ensure that `foreignKey.reference.fields` matches outer `fields`
-      if(_.isString(FK.get('fields'))) {
+      if(_.isString(FK.fields)) {
         if(!_.isString(FK.reference.fields)) {
           valid = false;
-          errors.concat('A JSON Table Schema foreignKey.reference.fields must match field names.');
+          errors = errors.concat('A JSON Table Schema foreignKey.reference.fields must match field names.');
         }
       } else {
         if(FK.fields.length !== FK.reference.fields.length) {
           valid = false;
-          errors.concat('A JSON Table Schema must have a fields key.');
+          errors = errors.concat('A JSON Table Schema must have a fields key.');
         }
       }
     });

--- a/models.js
+++ b/models.js
@@ -79,7 +79,7 @@ SchemaModel.prototype = _.extend(SchemaModel.prototype, {
   // duplicate field names.
   getField: function(fieldName, index) {
     try {
-      return _.where(this.fields(), {name: fieldName})[index];
+      return _.where(this.fields(), {name: fieldName})[index || 0];
     } catch(E) {
       return null;
     }

--- a/models.js
+++ b/models.js
@@ -29,22 +29,22 @@ function SchemaModel(source, options) {
   */
 
   this.source = source;
-  this.caseInsensitiveHeaders = options.caseInsensitiveHeaders;
+  this.caseInsensitiveHeaders = (options || {}).caseInsensitiveHeaders;
   asJs = this.toJs();
 
   if(_.isUndefined(asJs) || _.isNull(asJs))
     throw new Error('Invalid JSON');
-  
+
   if(!ensure(asJs)[0])
     throw new Error('Invalid schema');
 
-  this.asJs = this._expand(asJs);
+  this.asJs = this.expand(asJs);
   this.asJSON = JSON.stringify(this.asJs);
 }
 
 SchemaModel.prototype = _.extend(SchemaModel.prototype, {
   // Return boolean if value can be cast to fieldName's type.
-  cast: function(fieldName, value, index) { return this.get_type(fieldName, index || 0).cast(value); },
+  cast: function(fieldName, value, index) { return this.getType(fieldName, index || 0).cast(value); },
 
   // Expand the schema with additional default properties.
   expand: function(schema) {
@@ -86,7 +86,7 @@ SchemaModel.prototype = _.extend(SchemaModel.prototype, {
   },
 
   // Return all fields that match the given type.
-  get_fields_by_type: function(typeName) { return _.where(this.fields(), {type: typeName}); },
+  getFieldsByType: function(typeName) { return _.where(this.fields(), {type: typeName}); },
 
   // Return the `type` for `fieldName`.
   getType: function(fieldName, index) {
@@ -94,13 +94,13 @@ SchemaModel.prototype = _.extend(SchemaModel.prototype, {
 
 
     return this.typeMap[field.type](field);
-  }
+  },
 
   // Return boolean if the field exists in the schema.
-  has_field: function(fieldName) { return Boolean(this.getField(fieldName)); },
+  hasField: function(fieldName) { return Boolean(this.getField(fieldName)); },
 
   headers: function() {
-    var raw = _.chain(this.asJs.fields).map(_.property('name'));
+    var raw = _.chain(this.asJs.fields).map(_.property('name')).value();
 
 
     if(this.caseInsensitiveHeaders)
@@ -114,7 +114,8 @@ SchemaModel.prototype = _.extend(SchemaModel.prototype, {
   requiredHeaders: function() {
     var raw = _.chain(this.asJs.fields)
       .filter(function(F) { return F.constraints.required; })
-      .map(_.property('name'));
+      .map(_.property('name'))
+      .value();
 
 
     if(this.caseInsensitiveHeaders)
@@ -126,7 +127,7 @@ SchemaModel.prototype = _.extend(SchemaModel.prototype, {
   // Return schema as an Object.
   toJs: function() {
     try {
-      return utilities.loadJSONSource(this.source);
+      return utilities.loadJSONSource(this.source)._value;
     } catch(E) {
       return null;
     };

--- a/models.js
+++ b/models.js
@@ -1,0 +1,153 @@
+var _ = require('underscore');
+var ensure = require('./ensure');
+var types = require('./types');
+var utilities = require('./utilities');
+
+var DEFAULTS = {
+  constraints: {required: true},
+  format: 'default',
+  type: 'string'
+};
+
+function SchemaModel(source, options) {
+  /*
+  Model for a JSON Table Schema.
+
+  Providers handy helpers for ingesting, validating and outputting 
+  JSON Table Schemas: http://dataprotocols.org/json-table-schema/
+
+  Args:
+  * schema_source (string or dict): A filepath, url or dictionary 
+  that represents a schema
+  
+  * case_insensitive_headers (bool): if True, headers should be 
+  considered case insensitive, and `SchemaModel` forces all 
+  headers to lowercase when they are represented via a model 
+  instance. This setting **does not** mutate the actual strings 
+  that come from the the input schema_source, so out put methods
+  such as as_python and as_json are **not** subject to this flag.
+  */
+
+  this.source = source;
+  this.caseInsensitiveHeaders = options.caseInsensitiveHeaders;
+  asJs = this.toJs();
+
+  if(_.isUndefined(asJs) || _.isNull(asJs))
+    throw new Error('Invalid JSON');
+  
+  if(!ensure(asJs)[0])
+    throw new Error('Invalid schema');
+
+  this.asJs = this._expand(asJs);
+  this.asJSON = JSON.stringify(this.asJs);
+}
+
+SchemaModel.prototype = _.extend(SchemaModel.prototype, {
+  // Return boolean if value can be cast to fieldName's type.
+  cast: function(fieldName, value, index) { return this.get_type(fieldName, index || 0).cast(value); },
+
+  // Expand the schema with additional default properties.
+  expand: function(schema) {
+    return _.extend(schema, {fields: _.map(schema.fields || [], function(F) {
+      // Ensure we have a default type if no type was declared
+      if(!F.type)
+        F.type = DEFAULTS.type;
+
+      // Ensure we have a default format if no format was declared
+      if(!F.format)
+        F.format = DEFAULTS.format;
+
+      // Ensure we have a minimum constraints declaration
+      if(!F.constraints)
+        F.constraints = DEFAULTS.constraints;
+
+      else if(_.isUndefined(F.constraints.required))
+        F.constraints.required = DEFAULTS.constraints.required;
+
+      return F;
+    }, this)});
+  },
+
+  fields: function() { return this.asJs.fields; },
+  foreignKeys: function() { return this.asJs.foreignKeys; },
+
+  // Return the `constraints` object for `fieldName`.
+  getConstraints: function(fieldName, index) { return this.getField(fieldName, index || 0).constraints; },
+
+  // Return the `field` object for `fieldName`.
+  // `index` allows accessing a field name by position, as JTS allows
+  // duplicate field names.
+  getField: function(fieldName, index) {
+    try {
+      return _.where(this.fields(), {name: fieldName})[index];
+    } catch(E) {
+      return null;
+    }
+  },
+
+  // Return all fields that match the given type.
+  get_fields_by_type: function(typeName) { return _.where(this.fields(), {type: typeName}); },
+
+  // Return the `type` for `fieldName`.
+  getType: function(fieldName, index) {
+    var field = this.getField(fieldName, index || 0);
+
+
+    return this.typeMap[field.type](field);
+  }
+
+  // Return boolean if the field exists in the schema.
+  has_field: function(fieldName) { return Boolean(this.getField(fieldName)); },
+
+  headers: function() {
+    var raw = _.chain(this.asJs.fields).map(_.property('name'));
+
+
+    if(this.caseInsensitiveHeaders)
+      return _.invoke(raw, 'toLowerCase');
+
+    return raw;
+  },
+
+  primaryKey: function() { return this.asJs.primaryKey; },
+
+  requiredHeaders: function() {
+    var raw = _.chain(this.asJs.fields)
+      .filter(function(F) { return F.constraints.required; })
+      .map(_.property('name'));
+
+
+    if(this.caseInsensitiveHeaders)
+      return _.invoke(raw, 'toLowerCase');
+
+    return raw;
+  },
+
+  // Return schema as an Object.
+  toJs: function() {
+    try {
+      return utilities.loadJSONSource(this.source);
+    } catch(E) {
+      return null;
+    };
+  },
+
+  // Map a JSON Table Schema type to a JTSKit type class.
+  typeMap: {
+    string  : types.StringType,
+    number  : types.NumberType,
+    integer : types.IntegerType,
+    boolean : types.BooleanType,
+    null    : types.NullType,
+    array   : types.ArrayType,
+    object  : types.ObjectType,
+    date    : types.DateType,
+    time    : types.TimeType,
+    datetime: types.DateTimeType,
+    geopoint: types.GeoPointType,
+    geojson : types.GeoJSONType,
+    any     : types.AnyType
+  }
+});
+
+module.exports = SchemaModel;

--- a/test/models.js
+++ b/test/models.js
@@ -46,7 +46,11 @@ describe('Models', function() {
     done();
   });
 
-  it('have one of a field from passed schema', function(done, err) { assert(); done(); });
+  it('have one of a field from passed schema', function(done, err) {
+    assert((new SchemaModel(SCHEMA)).hasField('name'));
+    done();
+  });
+
   it('do not have fields not specified in passed schema', function(done, err) { assert(); done(); });
   it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });
   it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });

--- a/test/models.js
+++ b/test/models.js
@@ -56,6 +56,16 @@ describe('Models', function() {
     done();
   });
 
+  it('have correct number of fields of certain type', function(done, err) {
+    var model = new SchemaModel(SCHEMA);
+
+
+    assert.equal(model.getFieldsByType('string').length, 3);
+    assert.equal(model.getFieldsByType('number').length, 1);
+    assert.equal(model.getFieldsByType('integer').length, 1);
+    done();
+  });
+
   it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });
   it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });
   it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });

--- a/test/models.js
+++ b/test/models.js
@@ -1,9 +1,46 @@
 var _ = require('underscore');
 var assert = require('chai').assert;
+var SchemaModel = require('../models');
+
+var SCHEMA = {fields: [
+  {
+    name: 'id',
+    type: 'string',
+    constraints: {required: true}
+  },
+
+  {
+    name: 'height',
+    type: 'number',
+    constraints: {required: false}
+  },
+
+  {
+    name: 'age',
+    type: 'integer',
+    constraints: {required: false}
+  },
+
+  {
+    name: 'name',
+    type: 'string',
+    constraints: {required: true}
+  },
+
+  {
+    name: 'occupation',
+    type: 'string',
+    constraints: {required: false}
+  }
+]};
 
 
 describe('Models', function() {
-  it('have a correct number of header columns', function(done, err) { assert(); done(); });
+  it('have a correct number of header columns', function(done, err) {
+    assert.equal((new SchemaModel(SCHEMA)).headers().length, 5);
+    done();
+  });
+
   it('have a correct number of header required columns', function(done, err) { assert(); done(); });
   it('have one of a field from passed schema', function(done, err) { assert(); done(); });
   it('do not have fields not specified in passed schema', function(done, err) { assert(); done(); });

--- a/test/models.js
+++ b/test/models.js
@@ -51,7 +51,11 @@ describe('Models', function() {
     done();
   });
 
-  it('do not have fields not specified in passed schema', function(done, err) { assert(); done(); });
+  it('do not have fields not specified in passed schema', function(done, err) {
+    assert.notOk((new SchemaModel(SCHEMA)).hasField('religion'));
+    done();
+  });
+
   it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });
   it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });
   it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });

--- a/test/models.js
+++ b/test/models.js
@@ -93,5 +93,11 @@ describe('Models', function() {
     }
   });
 
-  it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });
+  it('raise exception when invalid format schema passed', function(done, err) {
+    try {
+      new SchemaModel({});
+    } catch(E) {
+      done();
+    }
+  });
 });

--- a/test/models.js
+++ b/test/models.js
@@ -1,41 +1,46 @@
 var _ = require('underscore');
 var assert = require('chai').assert;
 var SchemaModel = require('../models');
-
-var SCHEMA = {fields: [
-  {
-    name: 'id',
-    type: 'string',
-    constraints: {required: true}
-  },
-
-  {
-    name: 'height',
-    type: 'number',
-    constraints: {required: false}
-  },
-
-  {
-    name: 'age',
-    type: 'integer',
-    constraints: {required: false}
-  },
-
-  {
-    name: 'name',
-    type: 'string',
-    constraints: {required: true}
-  },
-
-  {
-    name: 'occupation',
-    type: 'string',
-    constraints: {required: false}
-  }
-]};
+var SCHEMA;
 
 
 describe('Models', function() {
+  beforeEach(function(done, err) {
+    SCHEMA = {fields: [
+      {
+        name: 'id',
+        type: 'string',
+        constraints: {required: true}
+      },
+
+      {
+        name: 'height',
+        type: 'number',
+        constraints: {required: false}
+      },
+
+      {
+        name: 'age',
+        type: 'integer',
+        constraints: {required: false}
+      },
+
+      {
+        name: 'name',
+        type: 'string',
+        constraints: {required: true}
+      },
+
+      {
+        name: 'occupation',
+        type: 'string',
+        constraints: {required: false}
+      }
+    ]};
+
+    done();
+  });
+
   it('have a correct number of header columns', function(done, err) {
     assert.equal((new SchemaModel(SCHEMA)).headers().length, 5);
     done();
@@ -66,7 +71,20 @@ describe('Models', function() {
     done();
   });
 
-  it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });
+  it('respect caseInsensitiveHeaders option', function(done, err) {
+    SCHEMA.fields = _.map(SCHEMA.fields, function(F) {
+      F.name = F.name[0].toUpperCase() + _.rest(F.name).join('').toLowerCase();
+      return F;
+    });
+
+    assert.deepEqual(
+      (new SchemaModel(SCHEMA, {caseInsensitiveHeaders: true})).headers().sort(),
+      ['id', 'height', 'name', 'age', 'occupation'].sort()
+    );
+
+    done();
+  });
+
   it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });
   it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });
 });

--- a/test/models.js
+++ b/test/models.js
@@ -85,6 +85,13 @@ describe('Models', function() {
     done();
   });
 
-  it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });
+  it('raise exception when invalid json passed as schema', function(done, err) {
+    try {
+      new SchemaModel('this is string');
+    } catch(E) {
+      done();
+    }
+  });
+
   it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });
 });

--- a/test/models.js
+++ b/test/models.js
@@ -41,7 +41,11 @@ describe('Models', function() {
     done();
   });
 
-  it('have a correct number of header required columns', function(done, err) { assert(); done(); });
+  it('have a correct number of header required columns', function(done, err) {
+    assert.equal((new SchemaModel(SCHEMA)).requiredHeaders().length, 2);
+    done();
+  });
+
   it('have one of a field from passed schema', function(done, err) { assert(); done(); });
   it('do not have fields not specified in passed schema', function(done, err) { assert(); done(); });
   it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });

--- a/test/models.js
+++ b/test/models.js
@@ -1,0 +1,13 @@
+var _ = require('underscore');
+var assert = require('chai').assert;
+
+
+describe('Models', function() {
+  it('have a correct number of header columns', function(done, err) { assert(); done(); });
+  it('have a correct number of header required columns', function(done, err) { assert(); done(); });
+  it('have one of a field from passed schema', function(done, err) { assert(); done(); });
+  it('do not have fields not specified in passed schema', function(done, err) { assert(); done(); });
+  it('respect caseInsensitiveHeaders option', function(done, err) { assert(); done(); });
+  it('raise exception when invalid json passed as schema', function(done, err) { assert(); done(); });
+  it('raise exception when invalid format schema passed', function(done, err) { assert(); done(); });
+});

--- a/utilities.js
+++ b/utilities.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Promise = require('promise-polyfill');
 var request = require('superagent');
 var url = require('url');
@@ -9,17 +10,17 @@ module.exports = {
   TRUE_VALUES: ['yes', 'y', 'true', 't', '1'],
   FALSE_VALUES: ['no', 'n', 'false', 'f', '0'],
 
-  isHash: function(value) { return !_.isObject(value) || _.isArray(value) || _.isFunction(value) },
+  isHash: function(value) { return _.isObject(value) && !_.isArray(value) && !_.isFunction(value); },
 
-  // Load a JSON source, from string, URL or buffer,  into a Python type.
+  // Load a JSON source, from string, URL or buffer, into a Python type.
   loadJSONSource: function(source) {
     if(_.isNull(source) || _.isUndefined(source) || _.isString(source))
       return null;
-    else if(_.isArray(source))
+    else if(_.isObject(source) && !_.isFunction(source))
       // The source has already been loaded. Return Promise object for consistency.
       return new Promise(function(RS, RJ) { RS(source); });
 
-    if(_.contains(REMOTE_SCHEMES, url.parse(source).protocol.replace(':', '')))
+    if(_.contains(module.exports.REMOTE_SCHEMES, url.parse(source).protocol.replace(':', '')))
       return new Promise(function(RS, RJ) {
         request
           .get(source)

--- a/utilities.js
+++ b/utilities.js
@@ -9,6 +9,8 @@ module.exports = {
   TRUE_VALUES: ['yes', 'y', 'true', 't', '1'],
   FALSE_VALUES: ['no', 'n', 'false', 'f', '0'],
 
+  isHash: function(value) { return !_.isObject(value) || _.isArray(value) || _.isFunction(value) },
+
   // Load a JSON source, from string, URL or buffer,  into a Python type.
   loadJSONSource: function(source) {
     if(_.isNull(source) || _.isUndefined(source) || _.isString(source))

--- a/utilities.js
+++ b/utilities.js
@@ -31,7 +31,6 @@ module.exports = {
 
             RS(JSON.parse(source));
           });
-
       });
 
     // WARN There is no possibility to have browser compatable code which can load file

--- a/utilities.js
+++ b/utilities.js
@@ -14,11 +14,11 @@ module.exports = {
 
   // Load a JSON source, from string, URL or buffer, into a Python type.
   loadJSONSource: function(source) {
-    if(_.isNull(source) || _.isUndefined(source) || _.isString(source))
+    if(_.isNull(source) || _.isUndefined(source))
       return null;
     else if(_.isObject(source) && !_.isFunction(source))
       // The source has already been loaded. Return Promise object for consistency.
-      return new Promise(function(RS, RJ) { RS(source); });
+      return source;
 
     if(_.contains(module.exports.REMOTE_SCHEMES, url.parse(source).protocol.replace(':', '')))
       return new Promise(function(RS, RJ) {


### PR DESCRIPTION
Initialization is different for schema passed as URL and schema passed as an object:

**Object**
```javascript
var model = new SchemaModel(schema, options);


model.headers().length
```

**URL**
```javascript
var model = new SchemaModel('http://google.com', options);


model.loadSource().then(function() { model.headers().length; });
```